### PR TITLE
Various fixes to be able to compile it

### DIFF
--- a/src/buttons/ioverlaybutton.h
+++ b/src/buttons/ioverlaybutton.h
@@ -15,7 +15,7 @@ public:
     }
 
 protected:
-    void enterEvent(QEnterEvent *event) override {
+    void enterEvent(QEvent *event) override {
         QPushButton::enterEvent(event);
         setEnabled(true); // Enable the button on hover enter
     }

--- a/src/container/ihistorylist.cpp
+++ b/src/container/ihistorylist.cpp
@@ -2,6 +2,7 @@
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QMenu>
+#include <QDebug>
 #include <QSpacerItem>
 #include <QShowEvent>
 #include <QAction>
@@ -15,7 +16,6 @@ IHistoryList::IHistoryList(QWidget *parent) : QListWidget(parent)
 void IHistoryList::deleteChat(bool checked)
 {
     delete this->takeItem(curr_index.row());
-    qDebug() << "itemDeleted(curr_index.row()) " << curr_index.row();
     emit itemDeleted(curr_index.row());
 }
 

--- a/src/container/ihistorylist.h
+++ b/src/container/ihistorylist.h
@@ -9,7 +9,6 @@
 class IHistoryItemDelegate : public QStyledItemDelegate {
 public:
     IHistoryItemDelegate(QObject *parent = nullptr) : QStyledItemDelegate(parent) {
-        qDebug() << "CustomItemDelegate created";
     }
 
     inline QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override {
@@ -21,7 +20,6 @@ public:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override {
         QStyledItemDelegate::paint(painter, option, index);
         if (!painter || !index.isValid()) {
-            qDebug() << "Invalid painter or model index.";
             return;
         }
 

--- a/src/display/imessagebox.cpp
+++ b/src/display/imessagebox.cpp
@@ -12,7 +12,7 @@ IMessageBox::IMessageBox(const QString &userName, const QString &avatar,
                          const QString &message, QWidget *parent)
     : QWidget(parent), avatarLabel(new QLabel(this)),
     userLabel(new QLabel(userName, this)),
-    messageBrowser(new IAutoResizeTextBrowser(this)), spinner(nullptr),
+    messageBrowser(new IAutoResizeTextBrowser(this)),
     m_message() {
     setupUI();
     setAvatar(avatar);
@@ -57,34 +57,11 @@ void IMessageBox::setupUI() {
 }
 
 void IMessageBox::setAnimation() {
-    // Setting up the spinner animation
-    QFrame *spinFrame = new QFrame(this);
-    spinFrame->setFixedSize(QSize(20, 20));
-    QVBoxLayout *layout = new QVBoxLayout(spinFrame);
-    spinner = new WaitingSpinnerWidget(spinFrame);
-
-    // Configuring the spinner properties
-    spinner->setFixedSize(QSize(10, 10));
-    spinner->setRoundness(100.0);
-    spinner->setMinimumTrailOpacity(15.0);
-    spinner->setTrailFadePercentage(10.0);
-    spinner->setNumberOfLines(10);
-    spinner->setLineLength(10);
-    spinner->setLineWidth(10);
-    spinner->setInnerRadius(0);
-    spinner->setRevolutionsPerSecond(1);
-    spinner->setColor(QColor(84, 210, 99));
-
-    layout->addWidget(spinner);
-    spinFrame->setLayout(layout);
-
-    spinner->start();
 }
 
 void IMessageBox::resizeEvent(QResizeEvent *event) {
     // Handling resize events to adjust spinner position
     QWidget::resizeEvent(event);
-    spinner->parentWidget()->setGeometry(messageBrowser->geometry());
 }
 
 void IMessageBox::setMarkdown(const QString &markdown) {
@@ -103,8 +80,6 @@ void IMessageBox::appendMessage(const QString &message) {
         return;
 
     // Stopping and hiding the spinner
-    spinner->stop();
-    spinner->parentWidget()->close();
 
     // Caching and displaying the message
     m_message += message;

--- a/src/objects/stylemanager.cpp
+++ b/src/objects/stylemanager.cpp
@@ -10,7 +10,6 @@ StyleManager::StyleManager(QObject *parent)
 void StyleManager::loadStyleSheet(const QString &filePath) {
     QFile file(filePath);
     if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        qDebug() << "Failed to open file for reading:" << filePath;
         return;
     }
 

--- a/src/pages/isettingpage.cpp
+++ b/src/pages/isettingpage.cpp
@@ -181,8 +181,6 @@ void ISettingPage::setupAccountWidget(QWidget *account) {
     layout->setAlignment(Qt::AlignTop);
 
     QPixmap avatar(ConfigManager::instance().config("avatar").toString());
-    qDebug() << "ConfigManager::instance().config(avatar).toString()"
-             << ConfigManager::instance().config("avatar").toString();
     m_avatarButton = new QPushButton(this);
     m_avatarButton->setFixedSize(60, 60);
     m_avatarButton->setStyleSheet(


### PR DESCRIPTION
Also I had to remove the spinner code otherwise don't compile it.

```
qollama/src/objects/stylemanager.cpp:13:9: error: calling 'debug' with incomplete return type 'QDebug'
   13 |         qDebug() << "Failed to open file for reading:" << filePath;

   /usr/bin/ld: CMakeFiles/qollama.dir/src/display/imessagebox.cpp.o: in function `IMessageBox::setAnimation()':
imessagebox.cpp:(.text+0x795): undefined reference to `WaitingSpinnerWidget::WaitingSpinnerWidget(QWidget*, bool, bool)'
/usr/bin/ld: imessagebox.cpp:(.text+0x7e6): undefined reference to `WaitingSpinnerWidget::setRoundness(double)'
/usr/bin/ld: imessagebox.cpp:(.text+0x7fb): undefined reference to `WaitingSpinnerWidget::setMinimumTrailOpacity(double)'
/usr/bin/ld: imessagebox.cpp:(.text+0x810): undefined reference to `WaitingSpinnerWidget::setTrailFadePercentage(double)'
/usr/bin/ld: imessagebox.cpp:(.text+0x822): undefined reference to `WaitingSpinnerWidget::setNumberOfLines(int)'
/usr/bin/ld: imessagebox.cpp:(.text+0x834): undefined reference to `WaitingSpinnerWidget::setLineLength(int)'
/usr/bin/ld: imessagebox.cpp:(.text+0x846): undefined reference to `WaitingSpinnerWidget::setLineWidth(int)'
/usr/bin/ld: imessagebox.cpp:(.text+0x855): undefined reference to `WaitingSpinnerWidget::setInnerRadius(int)'
/usr/bin/ld: imessagebox.cpp:(.text+0x86a): undefined reference to `WaitingSpinnerWidget::setRevolutionsPerSecond(double)'
/usr/bin/ld: imessagebox.cpp:(.text+0x8a7): undefined reference to `WaitingSpinnerWidget::setColor(QColor)'
/usr/bin/ld: imessagebox.cpp:(.text+0x8fc): undefined reference to `WaitingSpinnerWidget::start()'
/usr/bin/ld: CMakeFiles/qollama.dir/src/display/imessagebox.cpp.o: in function `IMessageBox::appendMessage(QString const&)':
imessagebox.cpp:(.text+0x9a8): undefined reference to `WaitingSpinnerWidget::stop()'
clang++-19: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/qollama.dir/build.make:639: qollama] Error 1
make[1]: *** [CMakeFiles/Makefile2:160: CMakeFiles/qollama.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

I did some fixes also to the gallerywidget for the same reasons.

Anyway I don't have any icons
![image](https://github.com/user-attachments/assets/774bcfb5-4ad6-4fba-ae6a-15d0ddc22f12)

When I executed it:
```
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setClipPath: Painter not active
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
QPixmap::scaled: Pixmap is a null pixmap
qt.svg: Cannot open file ':/icons/send.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/send.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/more-horiz.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/more-horiz.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setClipPath: Painter not active
INavigetrorBar created and UI setup completed
Setting up title
Setting up search line
Setting up navigator
INavigetrorBar created and UI setup completed
qt.svg: Cannot open file '://icons/account.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/account.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/prompt.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/prompt.svg', because: No such file or directory
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setClipPath: Painter not active
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file '://icons/sidebar-left.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
qt.svg: Cannot open file ':/icons/create-new.svg', because: No such file or directory
```

## Summary by Sourcery

Fixes compilation errors by removing the spinner code and addressing other issues in the gallery widget. Also, fixes some minor issues in other files.

Bug Fixes:
- Fixes a compilation error related to an incomplete return type in stylemanager.cpp.
- Fixes undefined references to `WaitingSpinnerWidget` in imessagebox.cpp by removing the spinner code.
- Fixes a compilation error in gallerywidget.
- Fixes a hover event in ioverlaybutton.h by changing the event type to QEvent.
- Fixes an issue where the painter or model index was invalid in IHistoryItemDelegate::paint().

Chores:
- Removes debug prints.