### PR TITLE
fix(qt6): noqt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 


### PR DESCRIPTION
RIght now use qt5 if found it but a lot of stuff gets broken...
Just removing and now works on linux.

## Summary by Sourcery

Force the project to use Qt6 instead of allowing Qt5. This resolves compatibility issues on Linux.